### PR TITLE
fix error raise if SNBinder.escape(number)

### DIFF
--- a/snbinder-0.5.3.js
+++ b/snbinder-0.5.3.js
@@ -190,7 +190,7 @@ var SNBinder = (function() {
             return {};
         },
         escape: function(text) { 
-            return text.replace(/&/g, '&amp;')
+            return String(text).replace(/&/g, '&amp;')
                        .replace(/'/g, '&#146;') //'
                        .replace(/</g, '&lt;')
                        .replace(/>/g, '&gt;')


### PR DESCRIPTION
test case
SNBinder.bind("$(.a.b)", {a: {b: 2}}, 0);
> Uncaught TypeError: text.replace is not a function(…)